### PR TITLE
Add dry-run option and refactor config

### DIFF
--- a/bench_opts.go
+++ b/bench_opts.go
@@ -1,0 +1,60 @@
+package bench
+
+import "time"
+
+// Option configures the benchmark runner
+// It mutates the internal config used by Run.
+type Option func(*config)
+
+// config holds runtime configuration for benchmarks.
+type config struct {
+	filename string
+	filter   string
+	samples  int
+	duration time.Duration
+	tableFmt string
+	showRef  bool
+	dryRun   bool
+}
+
+// WithFile sets the filename for benchmark results
+func WithFile(filename string) Option {
+	return func(c *config) {
+		c.filename = filename
+	}
+}
+
+// WithFilter sets a prefix filter for benchmark names
+func WithFilter(prefix string) Option {
+	return func(c *config) {
+		c.filter = prefix
+	}
+}
+
+// WithSamples sets the number of samples to collect per benchmark
+func WithSamples(n int) Option {
+	return func(c *config) {
+		c.samples = n
+	}
+}
+
+// WithDuration sets the duration for each sample
+func WithDuration(d time.Duration) Option {
+	return func(c *config) {
+		c.duration = d
+	}
+}
+
+// WithReference enables reference comparison column
+func WithReference() Option {
+	return func(c *config) {
+		c.showRef = true
+	}
+}
+
+// WithDryRun disables writing benchmark results to disk
+func WithDryRun() Option {
+	return func(c *config) {
+		c.dryRun = true
+	}
+}

--- a/bench_test.go
+++ b/bench_test.go
@@ -15,12 +15,14 @@ func TestWithOptions(t *testing.T) {
 	WithSamples(42)(&cfg)
 	WithDuration(123 * time.Millisecond)(&cfg)
 	WithReference()(&cfg)
+	WithDryRun()(&cfg)
 
 	assert.Equal(t, "foo.json", cfg.filename)
 	assert.Equal(t, "bar", cfg.filter)
 	assert.Equal(t, 42, cfg.samples)
 	assert.Equal(t, 123*time.Millisecond, cfg.duration)
 	assert.True(t, cfg.showRef)
+	assert.True(t, cfg.dryRun)
 }
 
 func TestFormatHelpers(t *testing.T) {
@@ -76,6 +78,16 @@ func TestRunWithReferenceAndNoPrev(t *testing.T) {
 	}, WithFile(file), WithReference())
 	_, err := os.Stat(file)
 	assert.NoError(t, err, "results file not created")
+}
+
+func TestRunDryRun(t *testing.T) {
+	file := "test_bench_dry.json"
+	defer os.Remove(file)
+	Run(func(b *B) {
+		b.Run("bench", func(b *B, op int) {})
+	}, WithFile(file), WithDryRun())
+	_, err := os.Stat(file)
+	assert.Error(t, err, "results file should not be created")
 }
 
 func TestFormatComparisonEdgeCases(t *testing.T) {


### PR DESCRIPTION
## Summary
- refactor option logic into `bench_opts.go`
- add `WithDryRun` option and `-n` CLI flag
- prevent saving results when dry-run is enabled
- test dry-run behaviour

## Testing
- `go test ./...` *(fails: flag redefined)*

------
https://chatgpt.com/codex/tasks/task_e_6860dae885208322b996837be614378d