### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ import "github.com/kelindar/bench"
 func main() {
     bench.Run(func(b *bench.B) {
         // Simple benchmark
-        b.Run("benchmark name", func() {
+        b.Run("benchmark name", func(b *bench.B, op int) {
             // code to benchmark
         })
 
         // Benchmark with reference comparison
         b.Run("benchmark vs ref",
-            func() { /* our implementation */ },
-            func() { /* reference implementation */ })
+            func(b *bench.B, op int) { /* our implementation */ },
+            func(b *bench.B, op int) { /* reference implementation */ })
     },
     bench.WithFile("results.json"),   // optional: set results file
     bench.WithFilter("set"),          // optional: only run benchmarks starting with "set"


### PR DESCRIPTION
## Summary
- fix the README example to use the correct benchmark function signature

## Testing
- `go test ./...` *(fails: flag redefined: bench)*

------
https://chatgpt.com/codex/tasks/task_e_6860db631458832297ec5ee76c841d37