### PR TITLE
Add gob codec and refactor file handling

### DIFF
--- a/bench_opts.go
+++ b/bench_opts.go
@@ -1,6 +1,9 @@
 package bench
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // Option configures the benchmark runner
 // It mutates the internal config used by Run.
@@ -15,12 +18,18 @@ type config struct {
 	tableFmt string
 	showRef  bool
 	dryRun   bool
+	codec    codec
 }
 
 // WithFile sets the filename for benchmark results
 func WithFile(filename string) Option {
 	return func(c *config) {
 		c.filename = filename
+		if strings.HasSuffix(filename, ".gob") {
+			c.codec = gobCodec{}
+		} else {
+			c.codec = jsonCodec{}
+		}
 	}
 }
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -23,6 +23,8 @@ func TestWithOptions(t *testing.T) {
 	assert.Equal(t, 123*time.Millisecond, cfg.duration)
 	assert.True(t, cfg.showRef)
 	assert.True(t, cfg.dryRun)
+	_, ok := cfg.codec.(jsonCodec)
+	assert.True(t, ok)
 }
 
 func TestFormatHelpers(t *testing.T) {
@@ -46,16 +48,6 @@ func TestShouldRun(t *testing.T) {
 	assert.False(t, b.shouldRun("bar"))
 	b.filter = ""
 	assert.True(t, b.shouldRun("anything"))
-}
-
-func TestSaveLoadResult(t *testing.T) {
-	file := "test_bench.json"
-	defer os.Remove(file)
-	b := &B{config: config{filename: file}}
-	res := Result{Name: "bench", Samples: []float64{1, 2, 3}, Timestamp: 123}
-	b.saveResult(res)
-	loaded := b.loadResults()
-	assert.Equal(t, int64(123), loaded["bench"].Timestamp)
 }
 
 func TestRunAndFiltering(t *testing.T) {

--- a/codec.go
+++ b/codec.go
@@ -1,0 +1,85 @@
+package bench
+
+import (
+	"encoding/gob"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// codec defines methods for encoding and decoding benchmark results.
+type codec interface {
+	load(filename string) map[string]Result
+	save(filename string, results map[string]Result) error
+}
+
+type jsonCodec struct{}
+
+type gobCodec struct{}
+
+func (jsonCodec) load(filename string) map[string]Result {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return make(map[string]Result)
+	}
+	var results map[string]Result
+	if err := json.Unmarshal(data, &results); err != nil {
+		return make(map[string]Result)
+	}
+	return results
+}
+
+func (jsonCodec) save(filename string, results map[string]Result) error {
+	data, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filename, data, 0644)
+}
+
+func (gobCodec) load(filename string) map[string]Result {
+	f, err := os.Open(filename)
+	if err != nil {
+		return make(map[string]Result)
+	}
+	defer f.Close()
+	dec := gob.NewDecoder(f)
+	var results map[string]Result
+	if err := dec.Decode(&results); err != nil {
+		return make(map[string]Result)
+	}
+	return results
+}
+
+func (gobCodec) save(filename string, results map[string]Result) error {
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := gob.NewEncoder(f)
+	return enc.Encode(results)
+}
+
+// loadResults loads previous results using the configured codec.
+func (r *B) loadResults() map[string]Result {
+	if r.codec == nil {
+		r.codec = jsonCodec{}
+	}
+	return r.codec.load(r.filename)
+}
+
+// saveResult saves a single result incrementally using the configured codec.
+func (r *B) saveResult(result Result) {
+	if r.dryRun {
+		return
+	}
+	if r.codec == nil {
+		r.codec = jsonCodec{}
+	}
+	current := r.loadResults()
+	current[result.Name] = result
+	if err := r.codec.save(r.filename, current); err != nil {
+		fmt.Printf("Error writing results file: %v\n", err)
+	}
+}

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,0 +1,30 @@
+package bench
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSaveLoadResult(t *testing.T) {
+	file := "test_codec.json"
+	defer os.Remove(file)
+	b := &B{config: config{filename: file, codec: jsonCodec{}}}
+	res := Result{Name: "bench", Samples: []float64{1, 2, 3}, Timestamp: 123}
+	b.saveResult(res)
+	loaded := b.loadResults()
+	if loaded["bench"].Timestamp != 123 {
+		t.Fatalf("expected timestamp 123")
+	}
+}
+
+func TestGobCodec(t *testing.T) {
+	file := "test_codec.gob"
+	defer os.Remove(file)
+	b := &B{config: config{filename: file, codec: gobCodec{}}}
+	res := Result{Name: "bench", Samples: []float64{1, 2, 3}, Timestamp: 321}
+	b.saveResult(res)
+	loaded := b.loadResults()
+	if loaded["bench"].Timestamp != 321 {
+		t.Fatalf("expected timestamp 321")
+	}
+}


### PR DESCRIPTION
## Summary
- support pluggable result codecs in a new `codec.go`
- choose codec via `WithFile` option (json or gob)
- use new codec functions for saving/loading
- fix command-line flag parsing in `Run`
- update tests and add new tests for codecs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6860dd36ff0c8322814aea9a37ec64b9