### PR TITLE
Replace tilde with equals sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ A **lightweight, statistical benchmarking library** for Go, designed for robust,
 name              time/op     ops/s      allocs/op  vs prev            vs ref
 ----------------- ----------- ---------- ---------- ------------------ ------------------
 and 1.0K (seq)    920.0 ns    1.1M       4          ✅ +7% (p=0.000)   ❌ -18% (p=0.000)
-and 1.0K (rnd)    665.9 ns    1.5M       4          ~ similar          ❌ -11% (p=0.000)
-and 1.0K (sps)    1.3 µs      754.5K     19         ~ similar          ~ -2% (p=0.004)
+and 1.0K (rnd)    665.9 ns    1.5M       4          🟰 similar          ❌ -11% (p=0.000)
+and 1.0K (sps)    1.3 µs      754.5K     19         🟰 similar          🟰 -2% (p=0.004)
 and 1.0K (dns)    172.0 ns    5.8M       4          ❌ -7% (p=0.000)   ❌ -18% (p=0.000)
-and 10.0M (seq)   191.3 µs    5.2K       156        ~ +5% (p=0.001)    ✅ +45% (p=0.000)
+and 10.0M (seq)   191.3 µs    5.2K       156        🟰 +5% (p=0.001)    ✅ +45% (p=0.000)
 and 10.0M (rnd)   274.1 µs    3.6K       176        ✅ +29% (p=0.000)  ✅ +2% (p=0.001)
 ```
 

--- a/format.go
+++ b/format.go
@@ -30,7 +30,7 @@ func (r *B) formatComparison(ourSamples, otherSamples []float64) string {
 		if our.Mean > 0 {
 			return "✅ +inf%"
 		}
-		return "~ similar"
+		return "🟰 similar"
 	}
 
 	speedup := our.Mean / other.Mean
@@ -39,7 +39,7 @@ func (r *B) formatComparison(ourSamples, otherSamples []float64) string {
 
 	// For non-significant changes close to zero, show "similar"
 	if !diff.Significant() && changePercent >= -2 && changePercent <= 2 {
-		return "~ similar"
+		return "🟰 similar"
 	}
 
 	var sign string
@@ -50,7 +50,7 @@ func (r *B) formatComparison(ourSamples, otherSamples []float64) string {
 	}
 
 	if !diff.Significant() {
-		return fmt.Sprintf("~ %s%.0f%% (p=%.3f)", sign, changePercent, diff.PValue)
+		return fmt.Sprintf("🟰 %s%.0f%% (p=%.3f)", sign, changePercent, diff.PValue)
 	}
 
 	if speedup > 1 {


### PR DESCRIPTION
## Summary
- use the heavy equals sign to indicate similarity or lack of significance
- update README example output accordingly

## Testing
- `go test -v ./...`


------
https://chatgpt.com/codex/tasks/task_e_6860e55dabf08322a6ea46290e376b63