### PR TITLE
Add configurable confidence option

### DIFF
--- a/bench.go
+++ b/bench.go
@@ -11,10 +11,11 @@ import (
 
 const (
 	// Default sampling configuration
-	DefaultSamples  = 100
-	DefaultDuration = 10 * time.Millisecond
-	DefaultTableFmt = "%-20s %-12s %-12s %-12s %-18s %-18s\n"
-	DefaultFilename = "bench.json"
+	DefaultSamples    = 100
+	DefaultDuration   = 10 * time.Millisecond
+	DefaultTableFmt   = "%-20s %-12s %-12s %-12s %-18s %-18s\n"
+	DefaultFilename   = "bench.json"
+	DefaultConfidence = 99.9
 )
 
 // Result represents a single benchmark result
@@ -33,11 +34,12 @@ type B struct {
 // Run executes benchmarks with the given configuration
 func Run(fn func(*B), opts ...Option) {
 	cfg := config{
-		filename: DefaultFilename,
-		samples:  DefaultSamples,
-		duration: DefaultDuration,
-		tableFmt: DefaultTableFmt,
-		codec:    jsonCodec{},
+		filename:   DefaultFilename,
+		samples:    DefaultSamples,
+		duration:   DefaultDuration,
+		tableFmt:   DefaultTableFmt,
+		confidence: DefaultConfidence,
+		codec:      jsonCodec{},
 	}
 
 	// Apply flags first so user options can override

--- a/bench_opts.go
+++ b/bench_opts.go
@@ -13,14 +13,15 @@ type Option func(*config)
 
 // config holds runtime configuration for benchmarks.
 type config struct {
-	filename string
-	filter   string
-	samples  int
-	duration time.Duration
-	tableFmt string
-	showRef  bool
-	dryRun   bool
-	codec    codec
+	filename   string
+	filter     string
+	samples    int
+	duration   time.Duration
+	tableFmt   string
+	showRef    bool
+	dryRun     bool
+	confidence float64
+	codec      codec
 }
 
 // WithFile sets the filename for benchmark results
@@ -67,6 +68,13 @@ func WithReference() Option {
 func WithDryRun() Option {
 	return func(c *config) {
 		c.dryRun = true
+	}
+}
+
+// WithConfidence sets the confidence level for statistical significance tests
+func WithConfidence(level float64) Option {
+	return func(c *config) {
+		c.confidence = level
 	}
 }
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -16,6 +16,7 @@ func TestWithOptions(t *testing.T) {
 	WithDuration(123 * time.Millisecond)(&cfg)
 	WithReference()(&cfg)
 	WithDryRun()(&cfg)
+	WithConfidence(95.5)(&cfg)
 
 	assert.Equal(t, "foo.json", cfg.filename)
 	assert.Equal(t, "bar", cfg.filter)
@@ -25,6 +26,7 @@ func TestWithOptions(t *testing.T) {
 	assert.True(t, cfg.dryRun)
 	_, ok := cfg.codec.(jsonCodec)
 	assert.True(t, ok)
+	assert.InDelta(t, 95.5, cfg.confidence, 0.001)
 }
 
 func TestShouldRun(t *testing.T) {

--- a/format.go
+++ b/format.go
@@ -35,7 +35,7 @@ func (r *B) formatComparison(ourSamples, otherSamples []float64) string {
 
 	speedup := our.Mean / other.Mean
 	changePercent := (speedup - 1) * 100
-	diff := tinystat.Compare(our, other, 99.9)
+	diff := tinystat.Compare(our, other, r.confidence)
 
 	// For non-significant changes close to zero, show "similar"
 	if !diff.Significant() && changePercent >= -2 && changePercent <= 2 {


### PR DESCRIPTION
## Summary
- add `DefaultConfidence` constant
- add `confidence` field in config and initialize it
- add `WithConfidence` option
- allow `formatComparison` to use configured confidence
- test the new option

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6860e56fd6f0832280dcc7d13e1116cf