### PR TITLE
Add RunN and update Run signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ import "github.com/kelindar/bench"
 func main() {
     bench.Run(func(b *bench.B) {
         // Simple benchmark
-        b.Run("benchmark name", func(b *bench.B, op int) {
+        b.Run("benchmark name", func(i int) {
             // code to benchmark
         })
 
         // Benchmark with reference comparison
         b.Run("benchmark vs ref",
-            func(b *bench.B, op int) { /* our implementation */ },
-            func(b *bench.B, op int) { /* reference implementation */ })
+            func(i int) { /* our implementation */ },
+            func(i int) { /* reference implementation */ })
     },
     bench.WithFile("results.json"),   // optional: set results file
     bench.WithFilter("set"),          // optional: only run benchmarks starting with "set"

--- a/bench_test.go
+++ b/bench_test.go
@@ -42,8 +42,8 @@ func TestRunAndFiltering(t *testing.T) {
 	defer os.Remove(file)
 	var ran, ranRef bool
 	Run(func(b *B) {
-		b.Run("foo", func(b *B, op int) { ran = true })
-		b.Run("bar", func(b *B, op int) {}, func(b *B, op int) { ranRef = true })
+		b.Run("foo", func(i int) { ran = true })
+		b.Run("bar", func(i int) {}, func(i int) { ranRef = true })
 	}, WithFile(file), WithFilter("foo"))
 	assert.True(t, ran, "filtered benchmark did not run")
 	assert.False(t, ranRef, "filtered out benchmark ran")
@@ -53,7 +53,7 @@ func TestRunWithReferenceAndNoPrev(t *testing.T) {
 	file := "test_bench3.json"
 	defer os.Remove(file)
 	Run(func(b *B) {
-		b.Run("bench", func(b *B, op int) {}, func(b *B, op int) {})
+		b.Run("bench", func(i int) {}, func(i int) {})
 	}, WithFile(file), WithReference())
 	_, err := os.Stat(file)
 	assert.NoError(t, err, "results file not created")
@@ -63,7 +63,7 @@ func TestRunDryRun(t *testing.T) {
 	file := "test_bench_dry.json"
 	defer os.Remove(file)
 	Run(func(b *B) {
-		b.Run("bench", func(b *B, op int) {})
+		b.Run("bench", func(i int) {})
 	}, WithFile(file), WithDryRun())
 	_, err := os.Stat(file)
 	assert.Error(t, err, "results file should not be created")


### PR DESCRIPTION
## Summary
- simplify benchmark callback by removing `*B` parameter
- introduce `RunN` to allow returning operation counts
- DRY up execution logic with internal `run` helper
- update tests and docs for new API

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6860e7c89d8c8322877747e4d3ee7211