### PR TITLE
Default to gob results

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 A **lightweight, statistical benchmarking library** for Go, designed for robust, repeatable, and insightful performance analysis. Bench makes it easy to:
 
 - **Analyze performance** with Welch's t-test for statistical significance
-- **Persist results** incrementally in JSON for resilience and tracking
+ - **Persist results** incrementally in Gob format for resilience and tracking
 - **Compare runs** and reference implementations with p-values
 - **Format output** in clean, customizable tables
 - **Filter benchmarks** by name prefix for focused runs

--- a/bench.go
+++ b/bench.go
@@ -14,7 +14,7 @@ const (
 	DefaultSamples    = 100
 	DefaultDuration   = 10 * time.Millisecond
 	DefaultTableFmt   = "%-20s %-12s %-12s %-12s %-18s %-18s\n"
-	DefaultFilename   = "bench.json"
+	DefaultFilename   = "bench.gob"
 	DefaultConfidence = 99.9
 )
 
@@ -39,7 +39,7 @@ func Run(fn func(*B), opts ...Option) {
 		duration:   DefaultDuration,
 		tableFmt:   DefaultTableFmt,
 		confidence: DefaultConfidence,
-		codec:      jsonCodec{},
+		codec:      gobCodec{},
 	}
 
 	// Apply flags first so user options can override

--- a/bench_opts.go
+++ b/bench_opts.go
@@ -83,7 +83,7 @@ func WithConfidence(level float64) Option {
 func initFlags(c *config) {
 	fs := flag.NewFlagSet("bench", flag.ContinueOnError)
 	prefix := fs.String("bench", "", "Run only benchmarks with this prefix")
-	dry := fs.Bool("n", false, "dry run - do not update bench.json")
+	dry := fs.Bool("n", false, "dry run - do not update bench.gob")
 
 	// Parse only the flags we care about from os.Args
 	args := []string{}


### PR DESCRIPTION
## Summary
- default benchmark results file to `bench.gob`
- update flag message to mention `bench.gob`
- note gob persistence in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6860eba8972c832281d8ecb6e6d2efe0