### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ A **lightweight, statistical benchmarking library** for Go, designed for robust,
 name              time/op     ops/s      allocs/op  vs prev            vs ref
 ----------------- ----------- ---------- ---------- ------------------ ------------------
 and 1.0K (seq)    920.0 ns    1.1M       4          ✅ +7% (p=0.000)   ❌ -18% (p=0.000)
-and 1.0K (rnd)    665.9 ns    1.5M       4          🟰 similar          ❌ -11% (p=0.000)
-and 1.0K (sps)    1.3 µs      754.5K     19         🟰 similar          🟰 -2% (p=0.004)
+and 1.0K (rnd)    665.9 ns    1.5M       4          🟰 similar         ❌ -11% (p=0.000)
+and 1.0K (sps)    1.3 µs      754.5K     19         🟰 similar         🟰 -2% (p=0.004)
 and 1.0K (dns)    172.0 ns    5.8M       4          ❌ -7% (p=0.000)   ❌ -18% (p=0.000)
-and 10.0M (seq)   191.3 µs    5.2K       156        🟰 +5% (p=0.001)    ✅ +45% (p=0.000)
+and 10.0M (seq)   191.3 µs    5.2K       156        🟰 +5% (p=0.001)   ✅ +45% (p=0.000)
 and 10.0M (rnd)   274.1 µs    3.6K       176        ✅ +29% (p=0.000)  ✅ +2% (p=0.001)
 ```
 
@@ -79,12 +79,12 @@ The benchmark runner can be customized with a set of option functions. The table
 
 | Option | Description |
 |--------|-------------|
-| `bench.WithFile("results.json")` | Use this to pick the file where benchmark results are stored. When the filename ends with `.gob`, the data is written in a compact binary format; otherwise JSON is used. Saving results lets you track performance over time or share them between machines. |
-| `bench.WithFilter("prefix")` | Runs only the benchmarks whose names start with the provided prefix. This is handy when your suite has many benchmarks and you only want to focus on a subset without changing your code. |
-| `bench.WithSamples(10)` | Sets how many samples should be collected for each benchmark. More samples give more stable statistics but also make the run take longer, so adjust the number depending on how precise you need the measurements to be. |
-| `bench.WithDuration(500*time.Millisecond)` | Controls how long each sample runs. Increase the duration when the code under test is very fast or when you want less variation between runs. |
-| `bench.WithReference()` | Enables the reference comparison column in the output. Provide a reference implementation when calling `b.Run` and Bench will show how your code performs against that reference, making regressions easy to spot. |
-| `bench.WithDryRun()` | Prevents the library from writing results to disk. This option is useful for quick experiments or CI jobs where you just want to see the formatted output without updating any files. |
+| `WithFile` | Use this to pick the file where benchmark results are stored. When the filename ends with `.gob`, the data is written in a compact binary format; otherwise JSON is used. Saving results lets you track performance over time or share them between machines. |
+| `WithFilter` | Runs only the benchmarks whose names start with the provided prefix. This is handy when your suite has many benchmarks and you only want to focus on a subset without changing your code. |
+| `WithSamples` | Sets how many samples should be collected for each benchmark. More samples give more stable statistics but also make the run take longer, so adjust the number depending on how precise you need the measurements to be. |
+| `WithDuration` | Controls how long each sample runs. Increase the duration when the code under test is very fast or when you want less variation between runs. |
+| `WithReference` | Enables the reference comparison column in the output. Provide a reference implementation when calling `b.Run` and Bench will show how your code performs against that reference, making regressions easy to spot. |
+| `WithDryRun` | Prevents the library from writing results to disk. This option is useful for quick experiments or CI jobs where you just want to see the formatted output without updating any files. |
 
 ## About
 


### PR DESCRIPTION
This pull request updates the `README.md` file to simplify the presentation of benchmark runner options by removing the `bench.` prefix from function names in the options table. This change improves readability and aligns the documentation with a more concise naming convention.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R87): Removed the `bench.` prefix from option function names (`WithFile`, `WithFilter`, `WithSamples`, `WithDuration`, `WithReference`, `WithDryRun`) to simplify their presentation in the options table.