### PR TITLE
Increase Go test coverage over 95%

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -28,3 +28,23 @@ func TestGobCodec(t *testing.T) {
 		t.Fatalf("expected timestamp 321")
 	}
 }
+
+func TestJSONCodecLoadError(t *testing.T) {
+	file := "bad.json"
+	os.WriteFile(file, []byte("bad"), 0644)
+	defer os.Remove(file)
+	res := jsonCodec{}.load(file)
+	if len(res) != 0 {
+		t.Fatalf("expected empty result")
+	}
+}
+
+func TestGobCodecLoadError(t *testing.T) {
+	file := "bad.gob"
+	os.WriteFile(file, []byte("bad"), 0644)
+	defer os.Remove(file)
+	res := gobCodec{}.load(file)
+	if len(res) != 0 {
+		t.Fatalf("expected empty result")
+	}
+}

--- a/format_test.go
+++ b/format_test.go
@@ -1,6 +1,7 @@
 package bench
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,4 +28,24 @@ func TestFormatComparisonEdgeCases(t *testing.T) {
 	assert.Equal(t, "new", b.formatComparison([]float64{1, 2, 3}, nil))
 	// Zero mean in reference
 	assert.Contains(t, b.formatComparison([]float64{1, 2, 3}, []float64{0, 0, 0}), "inf")
+}
+
+func TestFormatComparisonBranches(t *testing.T) {
+	b := &B{config: config{confidence: 99.9}}
+	// Identical samples -> similar
+	res := b.formatComparison([]float64{1, 2, 3, 4}, []float64{1, 2, 3, 4})
+	assert.Equal(t, "🟰 similar", res)
+
+	// Large but not significant difference
+	res = b.formatComparison([]float64{1, 2, 3, 4}, []float64{2, 4, 6, 8})
+	assert.True(t, strings.HasPrefix(res, "🟰 "))
+
+	// Significant improvement
+	b.confidence = 80
+	res = b.formatComparison([]float64{1, 2, 3, 4}, []float64{2, 4, 6, 8})
+	assert.True(t, strings.HasPrefix(res, "✅"))
+
+	// Significant regression
+	res = b.formatComparison([]float64{2, 4, 6, 8}, []float64{1, 2, 3, 4})
+	assert.True(t, strings.HasPrefix(res, "❌"))
 }


### PR DESCRIPTION
## Summary
- add tests for InitFlags, RunN and codec behaviors
- cover additional branches in formatComparison
- exercise error paths in codec implementations

## Testing
- `go test ./... -coverprofile=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_6860f11f7cfc8322aec7676a5398b22c