### PR TITLE
Change API to return a report

### DIFF
--- a/bench.go
+++ b/bench.go
@@ -78,9 +78,10 @@ func (r *B) shouldRun(name string) bool {
 }
 
 // benchmark runs a function repeatedly and returns performance samples
-func (r *B) benchmark(fn func(op int) int) (samples []float64, allocs []float64) {
-	samples = make([]float64, 0, r.samples)
+func (r *B) benchmark(fn func(op int) int) (timing []float64, allocs []float64) {
+	timing = make([]float64, 0, r.samples)
 	allocs = make([]float64, 0, r.samples)
+
 	for i := 0; i < r.samples; i++ {
 		// Force GC to get clean allocation measurements
 		runtime.GC()
@@ -101,33 +102,35 @@ func (r *B) benchmark(fn func(op int) int) (samples []float64, allocs []float64)
 		nsPerOp := float64(elapsed.Nanoseconds()) / float64(ops)
 		allocsPerOp := float64(m2.Mallocs-m1.Mallocs) / float64(ops)
 
-		samples = append(samples, nsPerOp)
+		timing = append(timing, nsPerOp)
 		allocs = append(allocs, allocsPerOp)
 	}
-	return samples, allocs
+	return timing, allocs
 }
 
 // Run executes a benchmark with optional reference comparison
-func (r *B) Run(name string, ourFn func(i int), refFn ...func(i int)) {
+func (r *B) Run(name string, ourFn func(i int), refFn ...func(i int)) Report {
 	var refWrapped func(int) int
 	if len(refFn) > 0 && refFn[0] != nil {
 		rf := refFn[0]
 		refWrapped = func(i int) int { rf(i); return 1 }
 	}
-	r.run(name, func(i int) int { ourFn(i); return 1 }, refWrapped)
+
+	return r.run(name, func(i int) int { ourFn(i); return 1 }, refWrapped)
 }
 
 // RunN executes a benchmark where each iteration may return the number of
 // operations performed. This allows amortizing expensive setup or batching.
-func (r *B) RunN(name string, ourFn func(i int) int, refFn ...func(i int) int) {
+func (r *B) RunN(name string, ourFn func(i int) int, refFn ...func(i int) int) Report {
 	var refWrapped func(int) int
 	if len(refFn) > 0 {
 		refWrapped = refFn[0]
 	}
-	r.run(name, ourFn, refWrapped)
+
+	return r.run(name, ourFn, refWrapped)
 }
 
-func (r *B) run(name string, ourFn func(int) int, refFn func(int) int) {
+func (r *B) run(name string, ourFn func(int) int, refFn func(int) int) (report Report) {
 	if !r.shouldRun(name) {
 		return
 	}
@@ -156,10 +159,10 @@ func (r *B) run(name string, ourFn func(int) int, refFn func(int) int) {
 
 	// Calculate delta vs previous run
 	prevResult, exists := prevResults[name]
-	delta := "new"
+	vsPrev := "new"
 	if exists {
-		report := bca(prevResult.Samples, ourSamples, r.confidence/100.0, boostramSamples)
-		delta = r.formatComparison(report)
+		report = bca(prevResult.Samples, ourSamples, r.confidence/100.0, boostramSamples)
+		vsPrev = r.formatComparison(report)
 	}
 
 	// Calculate vs reference if provided
@@ -177,7 +180,7 @@ func (r *B) run(name string, ourFn func(int) int, refFn func(int) int) {
 			formatTime(nsPerOp),
 			formatOps(opsPerSec),
 			formatAllocs(avgAllocsPerOp),
-			delta,
+			vsPrev,
 			vsRef)
 	} else {
 		fmt.Printf(r.tableFmt,
@@ -185,9 +188,10 @@ func (r *B) run(name string, ourFn func(int) int, refFn func(int) int) {
 			formatTime(nsPerOp),
 			formatOps(opsPerSec),
 			formatAllocs(avgAllocsPerOp),
-			delta, "")
+			vsPrev, "")
 	}
 
 	// Save result incrementally
 	r.saveResult(result)
+	return
 }


### PR DESCRIPTION
This pull request introduces changes to the benchmarking framework in `bench.go` to improve clarity and functionality. Key updates include renaming variables for better readability, modifying method signatures to return `Report` objects, and enhancing result comparison logic.

### Naming improvements for clarity:
* Renamed `samples` to `timing` in the `benchmark` method to better reflect its purpose of storing timing data. (`[[1]](diffhunk://#diff-232f219b741559de37dd62910124b914212a642f3e7a877b103de79e404dd368L81-R84)`, `[[2]](diffhunk://#diff-232f219b741559de37dd62910124b914212a642f3e7a877b103de79e404dd368L104-R133)`)
* Renamed `delta` to `vsPrev` in the `run` method to clarify its role as the comparison against previous results. (`[[1]](diffhunk://#diff-232f219b741559de37dd62910124b914212a642f3e7a877b103de79e404dd368L159-R165)`, `[[2]](diffhunk://#diff-232f219b741559de37dd62910124b914212a642f3e7a877b103de79e404dd368L180-R196)`)

### Enhanced method functionality:
* Updated `Run` and `RunN` method signatures to return `Report` objects, enabling better encapsulation and usability of benchmark results. (`[bench.goL104-R133](diffhunk://#diff-232f219b741559de37dd62910124b914212a642f3e7a877b103de79e404dd368L104-R133)`)
* Modified the `run` method to return a `Report` object, aligning its behavior with the updated `Run` and `RunN` methods. (`[[1]](diffhunk://#diff-232f219b741559de37dd62910124b914212a642f3e7a877b103de79e404dd368L159-R165)`, `[[2]](diffhunk://#diff-232f219b741559de37dd62910124b914212a642f3e7a877b103de79e404dd368L180-R196)`)