### PR TITLE
Add Assert helper for benchmarks

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -1,0 +1,35 @@
+package bench
+
+import (
+	"testing"
+)
+
+// Assert runs benchmarks in dry-run mode and fails the test if performance regresses.
+// It is skipped when testing is run with -short.
+func Assert(t *testing.T, fn func(*B), opts ...Option) {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("skipping benchmark assertion in short mode")
+	}
+
+	cfg := config{
+		filename:   DefaultFilename,
+		samples:    DefaultSamples,
+		duration:   DefaultDuration,
+		tableFmt:   DefaultTableFmt,
+		confidence: DefaultConfidence,
+		codec:      gobCodec{},
+	}
+
+	initFlags(&cfg)
+	cfg.dryRun = true
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	runner := &B{config: cfg, t: t}
+	runner.printHeader()
+	fn(runner)
+}

--- a/bench.go
+++ b/bench.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"testing"
 	"time"
 
 	"gonum.org/v1/gonum/stat"
@@ -33,6 +34,7 @@ type Result struct {
 // B manages benchmarks and handles persistence
 type B struct {
 	config
+	t *testing.T
 }
 
 // Run executes benchmarks with the given configuration
@@ -163,6 +165,9 @@ func (r *B) run(name string, ourFn func(int) int, refFn func(int) int) (report R
 	if exists {
 		report = bca(prevResult.Samples, ourSamples, r.confidence/100.0, boostramSamples)
 		vsPrev = r.formatComparison(report)
+		if r.t != nil && report.Significant && report.Delta > 0 {
+			r.t.Errorf("%s performance regressed: %s", name, vsPrev)
+		}
 	}
 
 	// Calculate vs reference if provided

--- a/bench_test.go
+++ b/bench_test.go
@@ -111,3 +111,25 @@ func TestRunWithBCaBootstrap(t *testing.T) {
 	_, err := os.Stat(file)
 	assert.NoError(t, err, "results file should be created")
 }
+
+func TestAssert(t *testing.T) {
+	file := "test_assert.json"
+	defer os.Remove(file)
+
+	// baseline run to create previous results
+	Run(func(b *B) {
+		b.Run("bench", func(i int) { time.Sleep(time.Millisecond) })
+	}, WithFile(file), WithSamples(5), WithDuration(time.Millisecond))
+
+	before, err := os.Stat(file)
+	assert.NoError(t, err)
+
+	// Assert should pass with identical performance and not modify file
+	Assert(t, func(b *B) {
+		b.Run("bench", func(i int) { time.Sleep(time.Millisecond) })
+	}, WithFile(file), WithSamples(5), WithDuration(time.Millisecond))
+
+	after, err := os.Stat(file)
+	assert.NoError(t, err)
+	assert.Equal(t, before.ModTime(), after.ModTime(), "file should not be modified")
+}


### PR DESCRIPTION
## Summary
- add `Assert` helper to run benchmarks from tests
- store testing.T in `B` to detect regressions
- implement regression detection and skip for short tests
- test to ensure Assert works and doesn't alter bench files

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68611fedc8648322a58b906e5711d25e