### PR TITLE
Compare allocation deltas using displayed integer values.

### DIFF
--- a/format.go
+++ b/format.go
@@ -115,17 +115,24 @@ func formatAllocsWithChange(allocsPerOp float64, change allocChange) string {
 	}
 }
 
+func allocIntValue(allocsPerOp float64) int64 {
+	if allocsPerOp < 1 {
+		return 0
+	}
+	return int64(math.Round(allocsPerOp))
+}
+
 func compareAllocs(previous, current []float64) allocChange {
 	if len(previous) == 0 || len(current) == 0 {
 		return allocUnknown
 	}
 
-	prevMedian := median(previous)
-	currMedian := median(current)
+	prev := allocIntValue(median(previous))
+	curr := allocIntValue(median(current))
 	switch {
-	case math.Abs(currMedian-prevMedian) <= 1e-9:
+	case curr == prev:
 		return allocSame
-	case currMedian < prevMedian:
+	case curr < prev:
 		return allocBetter
 	default:
 		return allocWorse

--- a/format_test.go
+++ b/format_test.go
@@ -64,4 +64,7 @@ func TestCompareAllocs(t *testing.T) {
 	assert.Equal(t, allocSame, compareAllocs([]float64{1, 1, 1}, []float64{1, 1, 1}))
 	assert.Equal(t, allocBetter, compareAllocs([]float64{2, 2, 2}, []float64{1, 1, 1}))
 	assert.Equal(t, allocWorse, compareAllocs([]float64{1, 1, 1}, []float64{2, 2, 2}))
+
+	// Float medians can differ while the displayed alloc count stays the same.
+	assert.Equal(t, allocSame, compareAllocs([]float64{35.8, 36.2}, []float64{36.1, 35.9}))
 }


### PR DESCRIPTION
Float median comparisons could flip the alloc icon even when the rounded count shown in output stayed the same.